### PR TITLE
ci(poetry): fix version compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        poetry-version: [1.1.4]
+        poetry-version: [1.2.0]
 
     defaults:
           run:


### PR DESCRIPTION
There is CI failure recently like https://github.com/OH-SHOWN/ohshown-backend/actions/runs/3207949696/jobs/5249771464

```
Successfully installed SecretStorage-3.3.3 cachecontrol-0.12.11 cachy-0.3.0 certifi-2022.9.24 cffi-1.15.1 charset-normalizer-2.1.1 cleo-0.8.1 clikit-0.6.2 crashtest-0.3.1 cryptography-38.0.1 distlib-0.3.6 filelock-3.8.0 html5lib-1.1 idna-3.4 importlib-metadata-1.7.0 jeepney-0.8.0 keyring-21.8.0 lockfile-0.12.2 msgpack-1.0.4 packaging-20.9 pastel-0.2.1 pexpect-4.8.0 pkginfo-1.8.3 platformdirs-2.5.2 poetry-1.1.4 poetry-core-1.3.2 ptyprocess-0.7.0 pycparser-2.21 pylev-1.4.0 pyparsing-3.0.9 requests-2.28.1 requests-toolbelt-0.9.1 shellingham-1.5.0 six-1.16.0 tomlkit-0.11.5 urllib3-1.26.12 virtualenv-20.16.2 webencodings-0.5.1 zipp-3.9.0
130
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
131
Traceback (most recent call last):
132
  File "/usr/local/bin/poetry", line 5, in <module>
133
    from poetry.console import main
134
  File "/usr/local/lib/python3.7/site-packages/poetry/console/__init__.py", line 1, in <module>
135
    from .application import Application
136
  File "/usr/local/lib/python3.7/site-packages/poetry/console/application.py", line 7, in <module>
137
    from .commands.about import AboutCommand
138
  File "/usr/local/lib/python3.7/site-packages/poetry/console/commands/__init__.py", line 2, in <module>
139
    from .add import AddCommand
140
  File "/usr/local/lib/python3.7/site-packages/poetry/console/commands/add.py", line 8, in <module>
141
    from .init import InitCommand
142
  File "/usr/local/lib/python3.7/site-packages/poetry/console/commands/init.py", line 16, in <module>
143
    from poetry.core.pyproject import PyProjectException
144
ImportError: cannot import name 'PyProjectException' from 'poetry.core.pyproject' (/usr/local/lib/python3.7/site-packages/poetry/core/pyproject/__init__.py)
145
Error: Process completed with exit code 1.
```